### PR TITLE
Add Legend of Elya — LLM inference on Nintendo 64 (MIPS R4300i)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -120,6 +120,7 @@ March 26, 2026 at 01:56:50 AM UTC
 * [TensorFlow Lite Micro: Embedded ML on Microcontrollers](https://arxiv.org/abs/2010.08678) — Covers architecture, design, and performance trade-offs
 * [On-Device Training Under 256 KB RAM](https://arxiv.org/abs/2203.09795) — Demonstrates methods for training ML models within severe memory constraints
 * [Benchmarking TinyML Systems](https://arxiv.org/abs/2112.01319) — Discusses performance evaluation and standardization needs in TinyML
+* [Legend of Elya](https://github.com/Scottcjn/legend-of-elya-n64) — World's first LLM on Nintendo 64. 819K-parameter nano-GPT transformer running live inference on the MIPS R4300i CPU (93.75 MHz, 4 MB RAM) at 60 tok/s. The ultimate TinyML demo: a Zelda-style dungeon crawler with AI NPCs on 1996 console hardware. Uses RSP vector unit for matrix multiplication.
 
 ## Tutorial
 


### PR DESCRIPTION
## Summary

Adds [Legend of Elya](https://github.com/Scottcjn/legend-of-elya-n64) to the Library section.

This is the world's first LLM running on Nintendo 64 hardware — an 819K-parameter nano-GPT transformer doing live inference on the MIPS R4300i CPU at 93.75 MHz with just 4 MB of RAM. Achieves 60 tokens/second using the N64's RSP vector unit for matrix multiplication.

This is arguably the most extreme TinyML deployment ever demonstrated:
- **CPU**: MIPS R4300i @ 93.75 MHz (1996)
- **RAM**: 4 MB total (model + game + framebuffer)
- **Model**: 4-layer transformer, 819K parameters
- **Speed**: 60 tok/s
- **Application**: Zelda-style dungeon crawler with AI NPCs

Full source code and playable .z64 ROM available. Built with libdragon SDK.