### PR TITLE
Add ForestHub.ai under Library

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -125,6 +125,7 @@ May 22, 2026 at 02:51:12 AM UTC
 * [On-Device Training Under 256 KB RAM](https://arxiv.org/abs/2203.09795) — Demonstrates methods for training ML models within severe memory constraints
 * [Benchmarking TinyML Systems](https://arxiv.org/abs/2112.01319) — Discusses performance evaluation and standardization needs in TinyML
 * [Legend of Elya](https://github.com/Scottcjn/legend-of-elya-n64) — World's first LLM on Nintendo 64. 819K-parameter nano-GPT transformer running live inference on the MIPS R4300i CPU (93.75 MHz, 4 MB RAM) at 60 tok/s. The ultimate TinyML demo: a Zelda-style dungeon crawler with AI NPCs on 1996 console hardware. Uses RSP vector unit for matrix multiplication.
+* [ForestHub.ai](https://foresthub.ai) — Platform for building, deploying and orchestrating embedded and edge AI agents on machines, controllers and industrial edge devices. Visual builder, local runtime, generated embedded code, hybrid edge-cloud orchestration.
 
 ## Tutorial
 


### PR DESCRIPTION
## Summary

Adds one entry under **Library** for [ForestHub.ai](https://foresthub.ai) — a platform for building, deploying and orchestrating embedded and edge AI agents on machines, controllers and industrial edge devices.

## Why this fits

Sits naturally alongside Edge Impulse — both are full-stack platforms targeting embedded devices — but ForestHub focuses on the agent layer (visual builder, local runtime, generated embedded code, hybrid edge-cloud orchestration) on top of TinyML inference.

## Disclosure

I'm affiliated with ForestHub.ai. Happy to adjust wording or move to a different section. Thanks for maintaining the list.